### PR TITLE
Run statistics

### DIFF
--- a/sfx_utils/geom_opt.py
+++ b/sfx_utils/geom_opt.py
@@ -36,27 +36,26 @@ class GeomOpt:
 
         n_proc = 0
         while n_proc < n_images:
-            try:
-                images = self.psi.get_images(batch_size, assemble=True)
-                
-                if ptype == 'max':
-                    if self.powder is None:
-                        self.powder = np.max(images, axis=0)
-                    else:
-                        self.powder = np.max(np.concatenate((self.powder[np.newaxis,:,:],
-                                                             images)), axis=0)
-                elif ptype == 'mean':
-                    if self.powder is None:
-                        self.powder = np.sum(images, axis=0)
-                    else:
-                        self.powder = np.sum(np.concatenate((self.powder[np.newaxis,:,:],
-                                                             images)), axis=0)
-                else:
-                    raise ValueError("Invalid powder type, must be max or mean")             
-                n_proc += batch_size
             
-            except:
-                print("Reached end of run")
+            images = self.psi.get_images(batch_size, assemble=True)
+    
+            if ptype == 'max':
+                if self.powder is None:
+                    self.powder = np.max(images, axis=0)
+                else:
+                    self.powder = np.max(np.concatenate((self.powder[np.newaxis,:,:], images)), axis=0)
+            
+            elif ptype == 'mean':
+                if self.powder is None:
+                    self.powder = np.sum(images, axis=0)
+                else:
+                    self.powder = np.sum(np.concatenate((self.powder[np.newaxis,:,:], images)), axis=0)
+                
+            else:
+                raise ValueError("Invalid powder type, must be max or mean") 
+            
+            n_proc += images.shape[0] # at end of run, might not equal batch size            
+            if images.shape[0] < batch_size: # reached end of the run
                 break
                     
         if ptype == 'mean':

--- a/sfx_utils/geom_opt.py
+++ b/sfx_utils/geom_opt.py
@@ -10,7 +10,7 @@ class GeomOpt:
                                   det_type=det_type) # detector name, string
         self.powder = None # for storing powder on the fly
         
-    def compute_powder(self, n_images=500, ptype='max'):
+    def compute_powder(self, n_images=500, batch_size=50, ptype='max'):
         """
         Compute the powder from the first n_images of the run, either by taking
         the maximum or average value of each pixel across the image series. The
@@ -19,7 +19,9 @@ class GeomOpt:
         Parameters
         ----------
         n_images : int
-            number of diffraction images
+            total number of diffraction images to process
+        batch_size: int
+            number of images per batch
         ptype : string
             if 'max', take the max pixel value
             if 'average', take the average pixel value
@@ -29,13 +31,37 @@ class GeomOpt:
         powder : numpy.ndarray, 2d
             powder diffraction image, in shape of assembled detector
         """
-        if ptype == 'max':
-            self.powder = np.amax(self.psi.get_images(n_images), axis=0)
-        elif ptype == 'mean':
-            self.powder = np.mean(self.psi.get_images(n_images), axis=0)
-        else:
-            raise ValueError("Invalid powder type, must be max or mean")
+        if batch_size > n_images:
+            batch_size = n_images
 
+        n_proc = 0
+        while n_proc < n_images:
+            try:
+                images = self.psi.get_images(batch_size, assemble=True)
+                
+                if ptype == 'max':
+                    if self.powder is None:
+                        self.powder = np.max(images, axis=0)
+                    else:
+                        self.powder = np.max(np.concatenate((self.powder[np.newaxis,:,:],
+                                                             images)), axis=0)
+                elif ptype == 'mean':
+                    if self.powder is None:
+                        self.powder = np.sum(images, axis=0)
+                    else:
+                        self.powder = np.sum(np.concatenate((self.powder[np.newaxis,:,:],
+                                                             images)), axis=0)
+                else:
+                    raise ValueError("Invalid powder type, must be max or mean")             
+                n_proc += batch_size
+            
+            except:
+                print("Reached end of run")
+                break
+                    
+        if ptype == 'mean':
+            self.powder /= float(n_proc)
+        
         return self.powder
 
     def opt_distance(self, sample='AgBehenate', n_images=500, center=None, plot=False):

--- a/sfx_utils/psana_interface.py
+++ b/sfx_utils/psana_interface.py
@@ -119,5 +119,9 @@ class PsanaInterface:
             else:
                 break
             counter += 1
+
+        if counter < num_images:
+            print("It appears we have reached the end of the run")
+            images = images[:counter]
             
         return images

--- a/sfx_utils/psana_interface.py
+++ b/sfx_utils/psana_interface.py
@@ -1,13 +1,16 @@
 import numpy as np
 import psana
 from psana import DataSource
+from psana import EventId
 
 class PsanaInterface:
 
-    def __init__(self, exp, run, det_type):
+    def __init__(self, exp, run, det_type, track_timestamps=False):
         self.exp = exp # experiment name, string
         self.run = run # run number, int
         self.det_type = det_type # detector name, string
+        self.track_timestamps = track_timestamps # bool, keep event info
+        self.seconds, self.nanoseconds, self.fiducials = [], [], []
         self.ds = psana.DataSource(f'exp={exp}:run={run}')
         self.det = psana.Detector(det_type, self.ds.env())
         
@@ -43,6 +46,22 @@ class PsanaInterface:
             estimated detector distance
         """
         return -1*np.mean(self.det.coords_z(self.run))/1e3
+
+    def get_timestamp(self, evtId):
+        """
+        Retrieve the timestamp (seconds, nanoseconds, fiducials) associated with the input 
+        event and store in self variables. For further details, see the example here:
+        https://confluence.slac.stanford.edu/display/PSDM/Jump+Quickly+to+Events+Using+Timestamps
+        
+        Parameters
+        ----------
+        evtId : psana.EventId
+            the event ID associated with a particular image
+        """
+        self.seconds.append(evtId.time()[0])
+        self.nanoseconds.append(evtId.time()[1])
+        self.fiducials.append(evtId.fiducials())
+        return
     
     def get_images(self, num_images, assemble=True):
         """
@@ -80,6 +99,8 @@ class PsanaInterface:
                         calibrate = False
                         if not calibrate and not assemble:
                             print("Warning: calibration data unavailable, returning uncalibrated data")
+
+                # retrieve image, by default calibrated and assembled into detector format
                 if assemble:
                     if not calibrate:
                         raise IOError("Error: calibration data not found for this run.")
@@ -90,6 +111,11 @@ class PsanaInterface:
                         images[counter] = self.det.calib(evt=evt)
                     else:
                         images[counter] = self.det.raw(evt=evt)
+
+                # optionally store timestamps associated with images
+                if self.track_timestamps:
+                    self.get_timestamp(evt.get(EventId))
+
             else:
                 break
             counter += 1

--- a/sfx_utils/run_diagnostics.py
+++ b/sfx_utils/run_diagnostics.py
@@ -112,4 +112,7 @@ class RunDiagnostics:
         else:
             ax1.set_title("Run statistics")
             
+        if output is not None:
+            f.savefig(output, dpi=300)
+
         return

--- a/sfx_utils/run_diagnostics.py
+++ b/sfx_utils/run_diagnostics.py
@@ -76,16 +76,16 @@ class RunDiagnostics:
         """
         n_proc = 0
         while n_proc < n_images:
-            try:
-                images = self.psi.get_images(batch_size, assemble=False)
-                for threshold in [None, max_devs]:
-                    batch_stats = self.compute_batch_stats(images, max_devs=threshold)
-                    self.wrangle_run_stats(batch_stats)
-                n_proc += batch_size
-                
-            except:
-                print("Reached the end of the run or requested number of images.")
+
+            images = self.psi.get_images(batch_size, assemble=False)
+            for threshold in [None, max_devs]:
+                batch_stats = self.compute_batch_stats(images, max_devs=threshold)
+                self.wrangle_run_stats(batch_stats)
+
+            n_proc += images.shape[0] # at end of run, might not equal batch size
+            if images.shape[0] < batch_size: # reached end of the run
                 break
+
         return
     
     def plot_run_stats(self, tag='', output=None):

--- a/sfx_utils/run_diagnostics.py
+++ b/sfx_utils/run_diagnostics.py
@@ -7,7 +7,6 @@ class RunDiagnostics:
     def __init__(self, exp, run, det_type):
         self.psi = PsanaInterface(exp=exp, run=run, det_type=det_type, track_timestamps=False)
         self.run_stats = dict()
-        self.powder = None
         
     def compute_batch_stats(self, images, max_devs=None):
         """

--- a/sfx_utils/run_diagnostics.py
+++ b/sfx_utils/run_diagnostics.py
@@ -1,0 +1,116 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from psana_interface import *
+
+class RunDiagnostics:
+    
+    def __init__(self, exp, run, det_type):
+        self.psi = PsanaInterface(exp=exp, run=run, det_type=det_type, track_timestamps=False)
+        self.run_stats = dict()
+        self.powder = None
+        
+    def compute_batch_stats(self, images, max_devs=None):
+        """
+        Compute statistics for a batch of images. Even when images are pre-calibrated,
+        some outliers may sneak through, so statistics are optionally computed after 
+        removing outliers (pixels that exceed max_devs std deviations above the mean).
+
+        Parameters
+        ----------
+        images : numpy.ndarray, 4d
+            unassembled, calibrated images of shape (n_images, n_panels, n_x, n_y)
+        max_devs : float, default=50
+            number of standard deviations above mean to consider pixels outliers
+            if None, do not perform additional outlier rejection.
+
+        Returns
+        -------
+        stats : dict
+            mean, standard deviation, median, max and min of each image
+            with and without an additional outlier removal step
+        """
+        tag = ''
+        if max_devs is not None:
+            means, stds = np.mean(images, axis=(1,2,3)), np.std(images, axis=(1,2,3))
+            images = np.where(np.abs(images - means[:,None,None,None]) < max_devs * stds[:,None,None,None], images, np.nan)
+            tag = '_sel'
+        
+        stats = dict()
+        stats['mean' + tag] = np.nanmean(images, axis=(1,2,3))
+        stats['std_dev' + tag] = np.nanstd(images, axis=(1,2,3))
+        stats['median' + tag] = np.nanmedian(images, axis=(1,2,3))
+        stats['max' + tag] = np.nanmax(images, axis=(1,2,3))
+        stats['min' + tag] = np.nanmin(images, axis=(1,2,3))
+        
+        return stats
+    
+    def wrangle_run_stats(self, batch_stats):
+        """
+        Store statistics from next batch of images.
+        
+        Parameters
+        ----------
+        batch_stats : dict
+            dictionary of statistics for a batch of images
+        """
+        for key in batch_stats.keys():
+            if key not in self.run_stats.keys():
+                self.run_stats[key] = list(batch_stats[key])
+            else:
+                self.run_stats[key].extend(list(batch_stats[key]))
+            
+        return
+        
+    def compute_run_stats(self, n_images=1e6, batch_size=100, max_devs=50):
+        """
+        Compute per-image statistics (mean, median, max, min, std deviation),
+        with and without an additional step of outlier rejection.
+        
+        Parameters
+        ----------
+        n_images : int 
+            number of images from run to process
+        batch_size : int
+            number of images per batch
+        max_devs : float
+            threshold for outlier removal (number of std deviations above mean)
+        """
+        n_proc = 0
+        while n_proc < n_images:
+            try:
+                images = self.psi.get_images(batch_size, assemble=False)
+                for threshold in [None, max_devs]:
+                    batch_stats = self.compute_batch_stats(images, max_devs=threshold)
+                    self.wrangle_run_stats(batch_stats)
+                n_proc += batch_size
+                
+            except:
+                print("Reached the end of the run or requested number of images.")
+                break
+        return
+    
+    def plot_run_stats(self, tag='', output=None):
+        """
+        Plot trajectories of run statistics.
+        
+        Parameters
+        ----------
+        tag : string
+            '' and '_sel' for pre and post outlier removal respectively
+        output : string
+            path for optionally saving plot to disk
+        """
+        f, (ax1,ax2,ax3,ax4) = plt.subplots(4,1, figsize=(10,8), sharex=True)
+
+        keys = ['mean', 'max', 'min', 'std_dev']
+        for ax,key in zip([ax1,ax2,ax3,ax4],keys):
+            ax.plot(self.run_stats[key + tag], c='black')
+            ax.set_ylabel(key, fontsize=12)
+        
+        ax.set_xlabel("Event", fontsize=12)
+        if tag == '_sel':
+            ax1.set_title("Run statistics after outlier removal")
+        else:
+            ax1.set_title("Run statistics")
+            
+        return


### PR DESCRIPTION
These changes address the features described in Issue #4. Statistics for the run can be retrieved and plotted as follows:
```
from run_diagnostics import *

rd = RunDiagnostics(exp='mfxp19619', run=19, det_type='epix10k2M')
rd.compute_run_stats(n_images=1500, batch_size=50)
rd.plot_run_stats(output="run.png") # plots from calibrated images
rd.plot_run_stats(output="run_clean.png", tag='_sel') # plots with additional outlier rejection step
```
which produces the plots below. The optional argument `max_devs` in `compute_run_stats` tunes the outlier rejection threshold and by default is set to 50 standard deviations above the mean of each image. If `n_images` is not supplied, the code (in principle) should compute statistics for the entire run. (An additional component of this PR was to enable timestamp tracking in `PsanaInterface`, though that functionality currently isn't used elsewhere in the code.)
![download-1](https://user-images.githubusercontent.com/6363287/150620406-8e60181f-4dbe-4711-97f3-238fab5fa15b.png)
![download](https://user-images.githubusercontent.com/6363287/150620408-9c41b84f-fa7b-4951-82d6-aeb11678b8cb.png)