### PR TITLE
catch problematic Begin chunk cases

### DIFF
--- a/sfx_utils/stream_interface.py
+++ b/sfx_utils/stream_interface.py
@@ -30,9 +30,12 @@ class StreamInterface:
         in_refl = False
 
         f = open(input_file)
-        for line in f:
+        for lc,line in enumerate(f):
             if line.find("Begin chunk") != -1:
                 n_chunk += 1
+                if in_refl:
+                    in_refl = False
+                    print(f"Warning! Line {lc} associated with chunk {n_chunk} is problematic: {line}")
             
             if line.find("Cell parameters") != -1:
                 cell = line.split()[2:5] + line.split()[6:9]
@@ -53,8 +56,11 @@ class StreamInterface:
 
                 if in_refl:
                     if line.find("h    k    l") == -1:
-                        reflection = np.array(line.split()[:7]).astype(float)
-                        stream_data.append(np.concatenate((np.array([n_chunk, n_cryst]), cell, reflection, np.array([-1]))))
+                        try:
+                            reflection = np.array(line.split()[:7]).astype(float)
+                            stream_data.append(np.concatenate((np.array([n_chunk, n_cryst]), cell, reflection, np.array([-1]))))
+                        except ValueError:
+                            print(f"Couldn't parse line {lc}: {line}")
                         continue
 
         f.close()


### PR DESCRIPTION
We encountered a problematic stream file in which the information for a subset of chunks was cut off, e.g.:
```
$ sed '16467210,16493293!d' r0029.stream  
-15   18   21      24.21     229.14     528.29     347.06  206.5 1174.8 p2a0
 -15   19   21    1316.01     236.----- Begin chunk -----
Image filename: /cds/data/drpsrcf/cxi/cxilz0720/scratch/cheetah/hdf5/r0029-sab1/cxilz0720-r0029_6.cxi
...
```
which caused problems during stream reading, since an `End of reflections` line at the end of the chunk was expected. The `read_stream` function has been modified such that these problematic lines will be interpreted as the end of a chunk. A warning will be printed out for each partial chunk encountered, but valid reflections prior to and following this problematic line will be included in the `stream_data` class variable. (Despite these seemingly problematic chunks, the remainder of the data from this stream file looks fine.)