### PR TITLE
Migration of powder calculation from GeomOpt to RunDiagnostics

### DIFF
--- a/sfx_utils/diagnostics/geom_opt.py
+++ b/sfx_utils/diagnostics/geom_opt.py
@@ -3,126 +3,29 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import matplotlib.colors as colors
 from matplotlib.colors import LogNorm
-from sfx_utils.interfaces.psana_interface import PsanaInterface
+from sfx_utils.diagnostics.run import RunDiagnostics
+from sfx_utils.interfaces.psana_interface import assemble_image_stack_batch
 from .ag_behenate import *
 
 class GeomOpt:
     
     def __init__(self, exp, run, det_type):
-        self.psi = PsanaInterface(exp=exp, # experiment name, string
-                                  run=run, # run number, int
-                                  det_type=det_type) # detector name, string
-        self.powder = None # for storing powder on the fly
+        self.diagnostics = RunDiagnostics(exp=exp, # experiment name, str
+                                          run=run, # run number, int
+                                          det_type=det_type) # detector name, str
         
-    def compute_powder(self, n_images=500, batch_size=50, ptype='max', plot=False):
-        """
-        Compute the powder from the first n_images of the run, either by taking
-        the maximum or average value of each pixel across the image series. The
-        powder will be stored as a self variable and ovewrite any stored powder.
-        
-        Parameters
-        ----------
-        n_images : int
-            total number of diffraction images to process
-        batch_size: int
-            number of images per batch
-        ptype : string
-            if 'max', take the max pixel value
-            if 'average', take the average pixel value
-        plot: bool
-            if True, displays the powder image and histogram.
-            
-        Returns
-        -------
-        powder : numpy.ndarray, 2d
-            powder diffraction image, in shape of assembled detector
-        """
-        if batch_size > n_images:
-            batch_size = n_images
-
-        n_proc = 0
-        while n_proc < n_images:
-            
-            images = self.psi.get_images(batch_size, assemble=True)
-    
-            if ptype == 'max':
-                if self.powder is None:
-                    self.powder = np.max(images, axis=0)
-                else:
-                    self.powder = np.max(np.concatenate((self.powder[np.newaxis,:,:], images)), axis=0)
-            
-            elif ptype == 'mean':
-                if self.powder is None:
-                    self.powder = np.sum(images, axis=0)
-                else:
-                    self.powder = np.sum(np.concatenate((self.powder[np.newaxis,:,:], images)), axis=0)
-                
-            else:
-                raise ValueError("Invalid powder type, must be max or mean") 
-            
-            n_proc += images.shape[0] # at end of run, might not equal batch size            
-            if images.shape[0] < batch_size: # reached end of the run
-                break
-                    
-        if ptype == 'mean':
-            self.powder /= float(n_proc)
-
-        if plot:
-            self.visualize_powder(self.powder)
-        
-        return self.powder
-
-    def visualize_powder(self, image, vmin=-1e5, vmax=1e5,
-                         output=None, figsize=12, dpi=300):
-        """
-        Visualize the powder image: the distribution of intensities as a histogram
-        and the positive and negative-valued pixels on the assembled detector image.
-        """
-        fig = plt.figure(figsize=(figsize,figsize),dpi=dpi)
-        gs = fig.add_gridspec(2,2)
-
-        irow=0
-        ax1 = fig.add_subplot(gs[irow,:2])
-        ax1.grid()
-        ax1.hist(image.flatten(), bins=100, log=True, color='black')
-        ax1.set_title(f'histogram of pixel intensities in powder sum ',
-                     fontdict={'fontsize': 8})
-
-        irow+=1
-        ax2 = fig.add_subplot(gs[irow,0])
-        im = ax2.imshow(np.where(image>0,0,image),
-                        cmap=plt.cm.gist_gray,
-                        norm=colors.SymLogNorm(linthresh=1., linscale=1.,
-                                               vmin=vmin, vmax=0.))
-        ax2.axis('off')
-        ax2.set_title(f'negative intensity pixels',
-                     fontdict={'fontsize': 6})
-        plt.colorbar(im)
-
-        ax3 = fig.add_subplot(gs[irow,1])
-        im = ax3.imshow(np.where(image<0,0,image),
-                        cmap=plt.cm.gist_yarg,
-                        norm=colors.SymLogNorm(linthresh=1., linscale=1.,
-                                               vmin=0, vmax=vmax))
-        ax3.axis('off')
-        ax3.set_title(f'positive intensity pixels',
-                     fontdict={'fontsize': 6})
-        plt.colorbar(im)
-
-        if output is not None:
-            plt.savefig(output)
-
-    def opt_distance(self, sample='AgBehenate', n_images=500, center=None, plot=False):
+    def opt_distance(self, powder, sample='AgBehenate', center=None, plot=False):
         """
         Estimate the sample-detector distance based on the properties of the powder
         diffraction image. Currently only implemented for silver behenate.
         
         Parameters
         ----------
-        sample : string
-            sample type, e.g. 'AgBehenate'
-        n_images : int
-            number of diffraction images
+        powder : str or int
+            if str, path to the powder diffraction in .npy format
+            if int, number of images from which to compute powder 
+        sampe : str
+            sample type, currently implemented for AgBehenate only
         center : tuple
             detector center (xc,yc) in pixels. if None, assume assembled image center.
         plot : bool
@@ -133,15 +36,24 @@ class GeomOpt:
         distance : float
             estimated sample-detector distance in mm
         """
-        if self.powder is None:
-            self.powder = self.compute_powder(n_images)
+        if type(powder) == str:
+            powder_img = np.load(powder)
+        
+        elif type(powder) == int:
+            print("Computing powder from scratch")
+            self.diagnostics.compute_run_stats(n_images=powder, powder_only=True)
+            powder_img = assemble_image_stack_batch(self.diagnostics.powders['max'], 
+                                                    self.diagnostics.pixel_index_map)
+        
+        else:
+            sys.exit("Unrecognized powder type, expected a path or number")
         
         if sample == 'AgBehenate':
             ag_behenate = AgBehenate()
-            distance = ag_behenate.opt_distance(self.powder,
-                                                self.psi.estimate_distance(),
-                                                self.psi.get_pixel_size(), 
-                                                self.psi.get_wavelength(),
+            distance = ag_behenate.opt_distance(powder_img,
+                                                self.diagnostics.psi.estimate_distance(),
+                                                self.diagnostics.psi.get_pixel_size(), 
+                                                self.diagnostics.psi.get_wavelength(),
                                                 center=center,
                                                 plot=plot)
             return distance


### PR DESCRIPTION
This PR addresses Issue #26. The changes include:
1. migration of the powder calculation from `GeomOpt` to `RunDiagnostics`.
2. calculation of the average and standard deviation powders in addition to the max, in case we wish to use these to generate a mask following DIALS' approach. Currently invalid values (due to taking the square root of a negative number) are left as `NaN` in the standard deviation powder; I'm not sure if this will cause issues moving forward.

The Wiki has also been updated to match the altered code.