### PR TITLE
Peaking finding and PsanaInterface parallelization overhaul

### DIFF
--- a/sfx_utils/interfaces/psana_interface.py
+++ b/sfx_utils/interfaces/psana_interface.py
@@ -76,6 +76,25 @@ class PsanaInterface:
         """
         return self.ds.env().epicsStore().value('SIOC:SYS0:ML00:AO192') * 10.
     
+    def get_wavelength_evt(self, evt):
+        """
+        Retrieve the detector's wavelength for a specfic event.
+
+        Parameters
+        ----------
+        evt : psana.Event object
+            individual psana event
+        
+        Returns
+        -------
+        wavelength : float
+            wavelength in Angstrom
+        """
+        ebeam = psana.Detector('EBeam')
+        photon_energy = ebeam.get(evt).ebeamPhotonEnergy()
+        lambda_m =  1.23984197386209e-06 / photon_energy # convert to meters using e=hc/lambda
+        return lambda_m * 1e10
+
     def estimate_distance(self):
         """
         Retrieve an estimate of the detector distance in mm.

--- a/sfx_utils/interfaces/psana_interface.py
+++ b/sfx_utils/interfaces/psana_interface.py
@@ -33,8 +33,8 @@ class PsanaInterface:
         
         self.ds = psana.DataSource(ds_args)   
         self.det = psana.Detector(det_type, self.ds.env())
-        self.run = next(self.ds.runs())
-        self.times = self.run.times()
+        self.runner = next(self.ds.runs())
+        self.times = self.runner.times()
         self.max_events = len(self.times)
         self._calib_data_available()
         
@@ -43,7 +43,7 @@ class PsanaInterface:
         Check whether calibration data is available.
         """
         self.calibrate = True
-        evt = self.run.event(self.times[0])
+        evt = self.runner.event(self.times[0])
         if (self.det.pedestals(evt) is None) or (self.det.gain(evt) is None):
             print("Warning: calibration data unavailable, returning uncalibrated data")
             self.calibrate = False
@@ -168,7 +168,7 @@ class PsanaInterface:
                 break
                 
             else:
-                evt = self.run.event(self.times[self.counter])
+                evt = self.runner.event(self.times[self.counter])
                 if assemble:
                     if not self.calibrate:
                         raise IOError("Error: calibration data not found for this run.")

--- a/sfx_utils/interfaces/psana_interface.py
+++ b/sfx_utils/interfaces/psana_interface.py
@@ -6,14 +6,53 @@ from PSCalib.GeometryAccess import GeometryAccess
 
 class PsanaInterface:
 
-    def __init__(self, exp, run, det_type, track_timestamps=False):
-        self.exp = exp # experiment name, string
+    def __init__(self, exp, run, det_type, ffb_mode=False, track_timestamps=False):
+        self.exp = exp # experiment name, str
         self.run = run # run number, int
-        self.det_type = det_type # detector name, string
+        self.det_type = det_type # detector name, str
         self.track_timestamps = track_timestamps # bool, keep event info
         self.seconds, self.nanoseconds, self.fiducials = [], [], []
-        self.ds = psana.DataSource(f'exp={exp}:run={run}')
+        self.set_up(det_type, ffb_mode)
+        self.counter = 0 
+
+    def set_up(self, det_type, ffb_mode):
+        """
+        Instantiate DataSource and Detector objects; use the run 
+        functionality to retrieve all psana.EventTimes.
+        
+        Parameters
+        ----------
+        det_type : str
+            detector type, e.g. epix10k2M or jungfrau4M
+        ffb_mode : bool
+            if True, set up in an FFB-compatible style
+        """
+        ds_args=f'exp={self.exp}:run={self.run}:idx'
+        if ffb_mode:
+            ds_args += f':dir=/cds/data/drpsrcf/{self.exp[:3]}/{self.exp}/xtc'
+        
+        self.ds = psana.DataSource(ds_args)   
         self.det = psana.Detector(det_type, self.ds.env())
+        self.run = next(self.ds.runs())
+        self.times = self.run.times()
+        self.max_events = len(self.times)
+        self._calib_data_available()
+        
+    def _calib_data_available(self):
+        """
+        Check whether calibration data is available.
+        """
+        self.calibrate = True
+        evt = self.run.event(self.times[0])
+        if (self.det.pedestals(evt) is None) or (self.det.gain(evt) is None):
+            print("Warning: calibration data unavailable, returning uncalibrated data")
+            self.calibrate = False
+            
+    def turn_calibration_off(self):
+        """
+        Do not apply calibration to images.
+        """
+        self.calibrate = False
         
     def get_pixel_size(self):
         """
@@ -63,17 +102,48 @@ class PsanaInterface:
         self.nanoseconds.append(evtId.time()[1])
         self.fiducials.append(evtId.fiducials())
         return
-    
+
+    def distribute_events(self, rank, total_ranks, max_events=-1):
+        """
+        For parallel processing. Update self.counter and self.max_events such that
+        events will be distributed evenly across total_ranks, and each rank will 
+        only process its assigned events. Hack to avoid explicitly using MPI here.
+        
+        Parameters
+        ----------
+        rank : int
+            current rank
+        total_ranks : int
+            total number of ranks
+        max_events : int, optional
+            total number of images desired, option to override self.max_events 
+        """
+        if max_events == -1:
+            max_events = self.max_events
+            
+        # determine boundary indices between ranks
+        split_indices = np.zeros(total_ranks)
+        for r in range(total_ranks):
+            num_per_rank = max_events // total_ranks
+            if r < (max_events % total_ranks):
+                num_per_rank += 1
+            split_indices[r] = num_per_rank
+        split_indices = np.append(np.array([0]), np.cumsum(split_indices)).astype(int)   
+        
+        # update self variables that determine start and end of this rank's batch
+        self.counter = split_indices[rank]
+        self.max_events = split_indices[rank+1]
+        
     def get_images(self, num_images, assemble=True):
         """
         Retrieve a fixed number of images from the run. If the pedestal or gain 
         information is unavailable and unassembled images are requested, return
-        uncalibrated images.
+        uncalibrated images. 
         
-        Paramters
+        Parameters
         ---------
         num_images : int
-            number of images to retrieve
+            number of images to retrieve (per rank)
         assemble : bool, default=True
             whether to assemble panels into image
             
@@ -82,51 +152,40 @@ class PsanaInterface:
         images : numpy.ndarray, shape ((num_images,) + det_shape)
             images retrieved sequentially from run, optionally assembled
         """
-        counter = 0
-        calibrate = True
-
+        # set up storage array
         if assemble:
             images = np.zeros((num_images, 
                                self.det.image_xaxis(self.run).shape[0], 
                                self.det.image_yaxis(self.run).shape[0]))
         else:
             images = np.zeros((num_images,) + self.det.shape())
-        
-        for num,evt in enumerate(self.ds.events()):
-            if counter < num_images:
-                # check that pedestal and gain information are available
-                if counter == 0:
-                    if (self.det.pedestals(evt) is None) or (self.det.gain(evt) is None):
-                        calibrate = False
-                        if not calibrate and not assemble:
-                            print("Warning: calibration data unavailable, returning uncalibrated data")
-
-                # retrieve image, by default calibrated and assembled into detector format
+            
+        # retrieve next batch of images
+        for counter_batch in range(num_images):
+            if self.counter >= self.max_events:
+                images = images[:counter_batch]
+                print("No more events to retrieve")
+                break
+                
+            else:
+                evt = self.run.event(self.times[self.counter])
                 if assemble:
-                    if not calibrate:
+                    if not self.calibrate:
                         raise IOError("Error: calibration data not found for this run.")
                     else:
-                        images[counter] = self.det.image(evt=evt)
+                        images[counter_batch] = self.det.image(evt=evt)
                 else:
-                    if calibrate:
-                        images[counter] = self.det.calib(evt=evt)
+                    if self.calibrate:
+                        images[counter_batch] = self.det.calib(evt=evt)
                     else:
-                        images[counter] = self.det.raw(evt=evt)
-
-                # optionally store timestamps associated with images
+                        images[counter_batch] = self.det.raw(evt=evt)
+                        
                 if self.track_timestamps:
                     self.get_timestamp(evt.get(EventId))
-
-            else:
-                break
-            counter += 1
-
-        if counter < num_images:
-            print("It appears we have reached the end of the run")
-            images = images[:counter]
-            
+                    
+                self.counter += 1
+             
         return images
-
 
 #### Miscellaneous functions ####
 

--- a/sfx_utils/processing/peak_finder.py
+++ b/sfx_utils/processing/peak_finder.py
@@ -477,6 +477,7 @@ if __name__ == '__main__':
                     mask=params.mask, psana_mask=params.psana_mask, min_peaks=params.min_peaks, max_peaks=params.max_peaks,
                     npix_min=params.npix_min, npix_max=params.npix_max, amax_thr=params.amax_thr, atot_thr=params.atot_thr, 
                     son_min=params.son_min, peak_rank=params.peak_rank, r0=params.r0, dr=params.dr, nsigm=params.nsigm)
+    print(f"Num ranks: {pf.size}")
     pf.find_peaks()
     pf.curate_cxi()
     pf.summarize()

--- a/sfx_utils/processing/peak_finder.py
+++ b/sfx_utils/processing/peak_finder.py
@@ -130,7 +130,7 @@ class PeakFinder:
                                         maxshape=(None, dim0, dim1),dtype=np.float32)
         data_1.attrs["axes"] = "experiment_identifier"
         
-        for key in ['powderHits', 'powderMisses']:
+        for key in ['powderHits', 'powderMisses', 'mask']:
             entry_1.create_dataset(f'/entry_1/data_1/{key}', (dim0, dim1), chunks=(dim0, dim1), maxshape=(dim0, dim1), dtype=float)
                 
         # peak-related keys
@@ -216,12 +216,13 @@ class PeakFinder:
         for key in ['eventNumber', 'machineTime', 'machineTimeNanoSeconds', 'fiducial']:
             outh5[f'/LCLS/{key}'].resize((self.n_hits,))
 
-        # add powders
+        # add powders and mask, reshaping to match crystfel conventions
         if self.powder_hits is not None:
             outh5["/entry_1/data_1/powderHits"][:] = self.powder_hits.reshape(-1, self.powder_hits.shape[-1])
         if self.powder_misses is not None:
             outh5["/entry_1/data_1/powderMisses"][:] = self.powder_misses.reshape(-1, self.powder_misses.shape[-1])
-            
+        outh5["/entry_1/data_1/mask"][:] = (1-self.mask).reshape(-1, self.mask.shape[-1]) # psocake inverts values 
+
         outh5.close()
     
     def _compute_peak_radius(self, peaks):

--- a/sfx_utils/processing/peak_finder.py
+++ b/sfx_utils/processing/peak_finder.py
@@ -235,7 +235,7 @@ class PeakFinder:
             
         # add distance, then crop the LCLS keys
         outh5['/LCLS/detector_1/EncoderValue'][:] = self.dist
-        for key in ['eventNumber', 'machineTime', 'machineTimeNanoSeconds', 'fiducial']:
+        for key in ['eventNumber', 'machineTime', 'machineTimeNanoSeconds', 'fiducial', 'detector_1/EncoderValue', 'photon_energy_eV']:
             outh5[f'/LCLS/{key}'].resize((self.n_hits,))
 
         # add powders and mask, reshaping to match crystfel conventions

--- a/sfx_utils/processing/peak_finder.py
+++ b/sfx_utils/processing/peak_finder.py
@@ -1,0 +1,320 @@
+import numpy as np
+import argparse
+import h5py
+import os
+from sfx_utils.interfaces.psana_interface import *
+from psalgos.pypsalgos import PyAlgos
+
+class PeakFinder:
+    
+    """
+    Perform adaptive peak-finding on a psana run and save the results to cxi
+    format. Adapted from psocake.
+    """
+    
+    def __init__(self, exp, run, det_type, outdir, tag='', mask=None, psana_mask=True, 
+                 min_peaks=2, max_peaks=2048, npix_min=2, npix_max=30, amax_thr=80., 
+                 atot_thr=120.,  son_min=7.0, peak_rank=3, r0=3.0, dr=2.0, nsigm=7.0):
+        
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        self.rank = comm.Get_rank()
+        self.size = comm.Get_size()
+        
+        # peak-finding algorithm parameters
+        self.npix_min = npix_min # int, min number of pixels in peak
+        self.npix_max = npix_max # int, max number of pixels in peak
+        self.amax_thr = amax_thr 
+        self.atot_thr = atot_thr
+        self.son_min = son_min # in psocake, nsigm=son_min
+        self.peak_rank = peak_rank # radius in which central pix is a local max, int
+        self.r0 = r0 # radius in pixels of ring for background evaluation, float
+        self.dr = dr # width in pixels of ring for background evaluation, float
+        self.nsigm = nsigm # intensity threshold to include pixel in connected group, float
+        self.min_peaks = min_peaks # int, min number of peaks per image
+        self.max_peaks = max_peaks # int, max number of peaks per image
+        
+        # set up 
+        self.psi = PsanaInterface(exp=exp, run=run, det_type=det_type, track_timestamps=True)
+        self.psi.distribute_events(self.rank, self.size)
+        self.n_events = self.psi.max_events
+        self.set_up_cxi(outdir, tag)
+        self.set_up_algorithm(mask_file=mask, psana_mask=psana_mask)  
+        
+    def _generate_mask(self, mask_file=None, psana_mask=True):
+        """
+        Generate mask, optionally a combination of the psana-generated mask
+        and a user-supplied mask.
+        
+        Parameters
+        ----------
+        mask_file : str
+            path to mask in shape of unassembled detector, optional
+        psana_mask : bool
+            if True, retrieve mask from psana Detector object
+        """
+        mask = np.ones(self.psi.det.shape()).astype(np.uint16)  
+        if psana_mask:
+            mask = self.psi.det.mask(self.psi.run, calib=False, status=True, 
+                                     edges=False, centra=False, unbond=False, 
+                                     unbondnbrs=False).astype(np.uint16)
+        if mask_file is not None:
+            mask *= np.load(mask_file).astype(np.uint16)
+        
+        self.mask = mask
+        
+    def set_up_algorithm(self, mask_file=None, psana_mask=True):
+        """
+        Set up the peak-finding algorithm. Currently only the adaptive
+        variant is supported. For more details, see:
+        https://github.com/lcls-psana/psalgos/blob/master/src/pypsalgos.py 
+        """
+        self._generate_mask(mask_file=mask_file, psana_mask=psana_mask)
+        self.alg = PyAlgos(mask=self.mask, pbits=0) # pbits controls verbosity
+        self.alg.set_peak_selection_pars(npix_min=self.npix_min,
+                                         npix_max=self.npix_max,
+                                         amax_thr=self.amax_thr,
+                                         atot_thr=self.atot_thr,
+                                         son_min=self.son_min)
+        self.n_hits = 0
+        self.powder_hits, self.powder_misses = None, None
+        
+        # additional self variables for tracking peak stats
+        self.iX = self.psi.det.indexes_x(self.psi.run).astype(np.int64)
+        self.iY = self.psi.det.indexes_y(self.psi.run).astype(np.int64)
+        self.ipx, self.ipy = self.psi.det.point_indexes(self.psi.run, pxy_um=(0, 0))
+
+    def set_up_cxi(self, outdir, tag=''):
+        """
+        Set up the CXI files to which peak finding results will be saved.
+        
+        Parameters
+        ----------
+        outdir : str
+            output directory
+        tag : str
+            file nomenclature suffix, optional
+        """
+        if (tag != '') and (tag[0]!='_'):
+            tag = '_' + tag
+        self.fname = os.path.join(outdir, f'{self.psi.exp}_{self.psi.run:04}_{self.rank}{tag}.cxi')
+        
+        outh5 = h5py.File(self.fname, 'w')
+        
+        # entry_1 dataset for downstream processing with CrystFEL
+        entry_1 = outh5.create_group("entry_1")
+        keys = ['nPeaks', 'peakXPosRaw', 'peakYPosRaw', 'rcent', 'ccent', 'rmin',
+                'rmax', 'cmin', 'cmax', 'peakTotalIntensity', 'peakMaxIntensity', 'peakRadius']
+        ds_expId = entry_1.create_dataset("experimental_identifier", (self.n_events,), maxshape=(None,), dtype=int)
+        ds_expId.attrs["axes"] = "experiment_identifier"
+        
+        # for storing images in crystFEL format
+        det_shape = self.psi.det.shape()
+        dim0, dim1 = det_shape[0] * det_shape[1], det_shape[2]
+        data_1 = entry_1.create_dataset('/entry_1/data_1/data', (self.n_events, dim0, dim1), chunks=(1, dim0, dim1),
+                                        maxshape=(None, dim0, dim1),dtype=np.float32)
+        data_1.attrs["axes"] = "experiment_identifier"
+        
+        for key in ['powderHits', 'powderMisses']:
+            entry_1.create_dataset(key, (dim0, dim1), chunks=(dim0, dim1), maxshape=(dim0, dim1), dtype=float)
+                
+        # peak-related keys
+        for key in keys:
+            if key == 'nPeaks':
+                ds_x = outh5.create_dataset(f'/entry_1/result_1/{key}', (self.n_events,), maxshape=(None,), dtype=int)
+                ds_x.attrs['minPeaks'] = self.min_peaks
+                ds_x.attrs['maxPeaks'] = self.max_peaks
+            else:
+                ds_x = outh5.create_dataset(f'/entry_1/result_1/{key}', (self.n_events,self.max_peaks), 
+                                            maxshape=(None,self.max_peaks), chunks=(1,self.max_peaks), dtype=float)
+            ds_x.attrs["axes"] = "experiment_identifier:peaks"
+            
+        # LCLS dataset to track event timestamps
+        lcls_1 = outh5.create_group("LCLS")
+        keys = ['eventNumber', 'machineTime', 'machineTimeNanoSeconds', 'fiducial']
+        
+        for key in keys:
+            ds_x = lcls_1.create_dataset(f'{key}', (self.n_events,), maxshape=(None,), dtype=int)
+            ds_x.attrs["axes"] = "experiment_identifier"
+            
+        outh5.close()
+    
+    def store_event(self, outh5, img, peaks):
+        """
+        Store event's peaks in CXI file, converting to Cheetah conventions.
+        
+        Parameters
+        ----------
+        outh5 : h5py._hl.files.File
+            open h5 file for storing output for this rank
+        img : numpy.ndarray, shape (n_panels, n_panels_fs, n_panels_ss)
+            calibrated detector data in shape of unassembled detector
+        peaks : numpy.ndarray, shape (n_peaks, 17)
+            results of peak finding algorithm for a single event
+        """
+        if self.psi.det_type not in ['jungfrau4M', 'epix10k2M']:
+            print("Warning! Reformatting to Cheetah may not be correct")
+        
+        ch_rows = peaks[:,0] * img.shape[1] + peaks[:,1]
+        ch_cols = peaks[:,2]
+        
+        # entry_1 entries for crystFEL processing
+        outh5['/entry_1/data_1/data'][self.n_hits,:,:] = img.reshape(-1, img.shape[-1]) 
+        outh5['/entry_1/result_1/nPeaks'][self.n_hits] = peaks.shape[0] 
+        outh5['/entry_1/result_1/peakXPosRaw'][self.n_hits,:peaks.shape[0]] = ch_cols.astype('int')
+        outh5['/entry_1/result_1/peakYPosRaw'][self.n_hits,:peaks.shape[0]] = ch_rows.astype('int')
+        
+        outh5['/entry_1/result_1/rcent'][self.n_hits,:peaks.shape[0]] = peaks[:,6] # row center of gravity
+        outh5['/entry_1/result_1/ccent'][self.n_hits,:peaks.shape[0]] = peaks[:,7] # col center of gravity
+        outh5['/entry_1/result_1/rmin'][self.n_hits,:peaks.shape[0]] = peaks[:,10] # minimal row of pixel group in the peak
+        outh5['/entry_1/result_1/rmax'][self.n_hits,:peaks.shape[0]] = peaks[:,11] # maximal row of pixel group in the peak
+        outh5['/entry_1/result_1/cmin'][self.n_hits,:peaks.shape[0]] = peaks[:,12] # minimal col pixel group in the peak
+        outh5['/entry_1/result_1/cmax'][self.n_hits,:peaks.shape[0]] = peaks[:,13] # maximal col of pixel group in the peak
+        
+        outh5['/entry_1/result_1/peakTotalIntensity'][self.n_hits,:peaks.shape[0]] = peaks[:,5]
+        outh5['/entry_1/result_1/peakMaxIntensity'][self.n_hits,:peaks.shape[0]] = peaks[:,4]
+        outh5['/entry_1/result_1/peakRadius'][self.n_hits,:peaks.shape[0]] = self._compute_peak_radius(peaks)
+        
+        # LCLS dataset - currently omitting timetool information
+        outh5['/LCLS/eventNumber'][self.n_hits] = self.psi.counter
+        outh5['/LCLS/machineTime'][self.n_hits] = self.psi.seconds[-1]
+        outh5['/LCLS/machineTimeNanoSeconds'][self.n_hits] = self.psi.nanoseconds[-1]
+        outh5['/LCLS/fiducial'][self.n_hits] = self.psi.fiducials[-1]
+        
+    def curate_cxi(self):
+        """
+        Curate the CXI file by reshaping the keys and adding powders.
+        """
+        outh5 = h5py.File(self.fname,"r+")
+        
+        # add powders
+        outh5["/entry_1/data_1/powderHits"][:] = self.powder_hits.reshape(-1, self.powder_hits.shape[-1])
+        outh5["/entry_1/data_1/powderMisses"][:] = self.powder_misses.reshape(-1, self.powder_misses.shape[-1])       
+        
+        # resize the CrystFEL keys
+        data_shape = outh5["/entry_1/data_1/data"].shape
+        outh5['/entry_1/data_1/data'].resize((self.n_hits, data_shape[1], data_shape[2]))
+
+        for key in ['peakXPosRaw', 'peakYPosRaw', 'rcent', 'ccent', 'rmin',
+                    'rmax', 'cmin', 'cmax' 'peakTotalIntensity', 'peakMaxIntensity', 'peakRadius']:
+            outh5[f'/entry_1/result_1/{key}'].resize(self.n_hits, self.max_peaks)
+            
+        # crop the LCLS keys
+        for key in ['eventNumber', 'machineTime', 'machineTimeNanoSeconds', 'fiducial']:
+            outh5[f'/LCLS.{key}'].resize((self.n_events,))
+            
+        outh5.close()
+    
+    def _compute_peak_radius(self, peaks):
+        """
+        Compute radii of peaks based on their constituent pixels.
+        
+        Parameters
+        ----------
+        peaks : numpy.ndarray, shape (n_peaks, 17)
+            results of peak finding algorithm for a single event
+            
+        Returns 
+        -------
+        radius : numpy.ndarray, shape (n_peaks)
+            radii of peaks in pixels
+        """
+        cenX = self.iX[np.array(peaks[:, 0], dtype=np.int64),
+                       np.array(peaks[:, 1], dtype=np.int64),
+                       np.array(peaks[:, 2], dtype=np.int64)] + 0.5 - self.ipx
+        cenY = self.iY[np.array(peaks[:, 0], dtype=np.int64),
+                       np.array(peaks[:, 1], dtype=np.int64),
+                       np.array(peaks[:, 2], dtype=np.int64)] + 0.5 - self.ipy
+        return np.sqrt((cenX ** 2) + (cenY ** 2))
+        
+    def find_peaks_event(self, img):
+        """
+        Find peaks on a single image.
+        
+        Parameters
+        ----------
+        img : numpy.ndarray, shape (n_panels, n_panels_fs, n_panels_ss)
+            calibrated detector data in shape of unassembled detector
+            
+        Returns
+        -------
+        peaks : numpy.ndarray, shape (n_peaks, 17)
+            results of peak finding algorithm for this image
+        """
+        peaks = self.alg.peak_finder_v3r3(img, rank=self.peak_rank, 
+                                          r0=self.r0, dr=self.dr, nsigm=self.nsigm) 
+        return peaks
+    
+    def find_peaks(self):
+        """
+        Find all peaks in the images assigned to this rank.
+        """
+        
+        start_idx, end_idx = self.psi.counter, self.psi.max_events
+        outh5 = h5py.File(self.fname,"r+")
+
+        for idx in range(start_idx, end_idx):
+            # retrieve calibrated image
+            evt = self.psi.runner.event(self.psi.times[self.psi.counter])
+            self.psi.get_timestamp(evt.get(EventId))
+            img = self.psi.det.calib(evt=evt)
+            
+            # search for peaks and store if found
+            peaks = self.find_peaks_event(img)
+            if (peaks.shape[0] >= self.min_peaks) and (peaks.shape[0] <= self.max_peaks):
+                self.store_event(outh5, img, peaks)
+                self.n_hits+=1
+                print(idx, peaks.shape[0], self.psi.fiducials[-1])
+                
+            # generate / update powders
+            if peaks.shape[0] >= self.min_peaks:
+                if self.powder_hits is None:
+                    self.powder_hits = img
+                else:
+                    self.powder_hits = np.maximum(self.powder_hits, img)
+            else:
+                if self.powder_misses is None:
+                    self.powder_misses = img
+                else:
+                    self.powder_misses = np.maximum(self.powder_misses, img)
+                
+            self.psi.counter+=1
+            
+        outh5.close()
+                        
+#### For command line use ####
+            
+def parse_input():
+    """
+    Parse command line input.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-e', '--exp', help='Experiment name', required=True, type=str)
+    parser.add_argument('-r', '--run', help='Run number', required=True, type=int)
+    parser.add_argument('-d', '--det_type', help='Detector name, e.g epix10k2M or jungfrau4M',  required=True, type=str)
+    parser.add_argument('-o', '--outdir', help='Output directory for cxi files', required=True, type=str)
+    parser.add_argument('-t', '--tag', help='Tag to append to cxi file names', required=False, type=str, default='')
+    parser.add_argument('-m', '--mask', help='Binary mask', required=False, type=str)
+    parser.add_argument('--psana_mask', help='If True, apply mask from psana Detector object', required=False, type=bool, default=True)
+    parser.add_argument('--min_peaks', help='Minimum number of peaks per image', required=False, type=int, default=2)
+    parser.add_argument('--max_peaks', help='Maximum number of peaks per image', required=False, type=int, default=2048)
+    parser.add_argument('--npix_min', help='Minimum number of pixels per peak', required=False, type=int, default=2)
+    parser.add_argument('--npix_max', help='Maximum number of pixels per peak', required=False, type=int, default=30)
+    parser.add_argument('--amax_thr', help='', required=False, type=float, default=80.)
+    parser.add_argument('--atot_thr', help='', required=False, type=float, default=120.)
+    parser.add_argument('--son_min', help='', required=False, type=float, default=7.0)
+    parser.add_argument('--peak_rank', help='Radius in which central peak pixel is a local maximum', required=False, type=int, default=3)
+    parser.add_argument('--r0', help='Radius of ring for background evaluation in pixels', required=False, type=float, default=3.0)
+    parser.add_argument('--dr', help='Width of ring for background evaluation in pixels', required=False, type=float, default=2.0)
+    parser.add_argument('--nsigm', help='Intensity threshold to include pixel in connected group', required=False, type=float, default=7.0)
+    
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    
+    params = parse_input()
+    pf = PeakFinder(exp=params.exp, run=params.run, det_type=params.det_type, outdir=params.outdir, tag=params.tag,
+                    mask=params.mask, psana_mask=params.psana_mask, min_peaks=params.min_peaks, max_peaks=params.max_peaks,
+                    npix_min=params.npix_min, npix_max=params.npix_max, amax_thr=params.amax_thr, atot_thr=params.atot_thr, 
+                    son_min=params.son_min, peak_rank=params.peak_rank, r0=params.r0, dr=params.dr, nsigm=params.nsigm)
+    pf.find_peaks()


### PR DESCRIPTION
A `PeakFinder` class has been added that leverages `psana`'s adaptive peak-finding algorithm and writes the results to CrystFEL-compatible CXI files that can then be indexed using `indexamajig`. In addition, the class writes a summary file (peakfinding.summary) and a .lst file as input for `indexamajig`. As an example, peak finding can be performed as follows:

```
mpirun -n 4 python /cds/home/a/apeck/sfx_utils/sfx_utils/processing/peak_finder.py --exp cxip21119 --run 46 --det_type jungfrau4M --outdir /cds/data/psdm/cxi/cxip21119/scratch/apeck/r0046 --mask /cds/data/psdm/cxi/cxip21119/scratch/apeck/r0046/staticMask.npy --amax_thr 180.0 --atot_thr 300.0
```

To enable MPI parallelization during peak finding, the `PsanaInterface` class has been revised so that the event IDs are retrieved at the beginning and can be distributed across ranks using the `distribute_events` class function. Note that despite these changes `PsanaInterface` has no knowledge of MPI so that it can be used without `mpirun`; `mpi4py` should be imported by the upstream class. It may be useful to look into whether `MPIDataSource` would be an efficient alternative at a later date.

To-do's:
1. Make a peak finding task.
2. Figure out what the `amax_thr`, `atot_thr`, and `son_min` variables correspond to, and look into whether the new `psana` interface for peak finding is avalable.
3. Alter `generate_mask` function in the `PeakFinder` class to detect type of mask (e.g. cctbx, crystfel, psana unassembled) and load accordingly.